### PR TITLE
RCJ, seperated the catheter grid status text so that it will not have…

### DIFF
--- a/src/catheter_arduino_gui/inc/gui/catheter_grid.h
+++ b/src/catheter_arduino_gui/inc/gui/catheter_grid.h
@@ -13,6 +13,8 @@
 #include "com\catheter_commands.h"
 
 // This file defines the grid in which commands are entered and run.
+// This object does not require any threaded communication as it is only 
+// changed by the main thread.
 
 class CatheterGrid : public wxGrid {
     public:

--- a/src/catheter_arduino_gui/inc/gui/catheter_gui.h
+++ b/src/catheter_arduino_gui/inc/gui/catheter_gui.h
@@ -31,6 +31,7 @@ public:
     void OnSendCommandsButtonClicked(wxCommandEvent& e);
     void OnSendResetButtonClicked(wxCommandEvent& e);
 	void OnSendPollButtonClicked(wxCommandEvent& e);
+	void onIdle(wxIdleEvent& e);
 
     enum {
         ID_SELECT_PLAYFILE_BUTTON = 1024,
@@ -70,8 +71,10 @@ private:
     // status panel
     //wxStaticText* statusText;
 	CatheterStatusText *statusText;
+	incomingText* statusTextData;
 
 	//status Grid
+	statusData * statusGridCmdPtr;
 	StatusGrid * statusGridPtr;
 
     // control buttons

--- a/src/catheter_arduino_gui/inc/gui/status_frame.h
+++ b/src/catheter_arduino_gui/inc/gui/status_frame.h
@@ -13,6 +13,22 @@
 // catheter channels. (ADC and DAC)
 // This is the status frame.
 
+// a shared object is included to avoid race conditions.
+struct statusData
+{
+	boost::mutex statusMutex;
+	std::vector<CatheterChannelCmd> inputCommands;
+	bool updated;
+
+	// update function.
+	void updateCmdList(std::vector<CatheterChannelCmd> & inputCommands);
+
+	statusData() : updated(false)
+	{};
+};
+
+
+
 class StatusGrid: public wxFlexGridSizer
 {
 
@@ -20,14 +36,14 @@ public:
 	 StatusGrid(wxPanel* parent);
     ~StatusGrid();
 
-    void updateStatus(const std::vector<CatheterChannelCmd> & inputCommands);
+    void updateStatus(statusData*);
 
-    void SetCommands(const std::vector<CatheterChannelCmdSet>& cmds);
-	void GetCommands(std::vector<CatheterChannelCmdSet>& cmds);
-    void ResetDefault();
+    // void SetCommands(const std::vector<CatheterChannelCmdSet>& cmds);
+	// void GetCommands(std::vector<CatheterChannelCmdSet>& cmds);
+    // void ResetDefault();
 
 private:
-	boost::mutex statusMutex;
+	
 
 	std::vector < wxTextCtrl* > textCtrl;
 

--- a/src/catheter_arduino_gui/inc/gui/status_text.h
+++ b/src/catheter_arduino_gui/inc/gui/status_text.h
@@ -9,6 +9,19 @@
 
 // This file defines the status text box.
 
+struct incomingText
+{
+	boost::mutex textMutex;
+	std::string stringData;
+	bool update;
+
+	incomingText() : update(false)
+	{
+	};
+
+	void appendText(const std::string  &newText);
+};
+
 class CatheterStatusText : public wxScrolledWindow {
 public:
 	
@@ -16,7 +29,7 @@ public:
     explicit CatheterStatusText(wxWindow* parent, wxWindowID id);
 
     // public method to send text into the status box
-    bool addText(const std::string &incomingInfo);
+    bool addText(incomingText*);
 	bool addWxText(const wxString& msg);
 
 private:

--- a/src/catheter_arduino_gui/inc/ser/serial_thread.h
+++ b/src/catheter_arduino_gui/inc/ser/serial_thread.h
@@ -17,8 +17,8 @@ class SerialThreadObject
 public:
 	
 	SerialThreadObject();
-	void setStatusTextPtr(CatheterStatusText*);
-	void setStatusGrid(StatusGrid* );
+	void setStatusTextPtr(incomingText*);
+	void setStatusGrid(statusData*);
 
 	
 enum ThreadCmd {
@@ -82,20 +82,10 @@ private:
 
 
 	// gui handles
-	CatheterStatusText* textStatus;
-	StatusGrid* gridStatus;
+	statusData * statusGridData;
+	
+	incomingText* textStatusData;
 };
-
-
-
-
-
-
-
-
-
-
-
 
 
 #endif

--- a/src/catheter_arduino_gui/src/gui/catheter_gui.cpp
+++ b/src/catheter_arduino_gui/src/gui/catheter_gui.cpp
@@ -49,7 +49,15 @@ wxBEGIN_EVENT_TABLE(CatheterGuiFrame, wxFrame)
     EVT_BUTTON(CatheterGuiFrame::ID_SEND_COMMANDS_BUTTON, CatheterGuiFrame::OnSendCommandsButtonClicked)
     EVT_BUTTON(CatheterGuiFrame::ID_SEND_RESET_BUTTON, CatheterGuiFrame::OnSendResetButtonClicked)
 	EVT_BUTTON(CatheterGuiFrame::ID_SEND_POLL_BUTTON, CatheterGuiFrame::OnSendPollButtonClicked)
+	EVT_IDLE(CatheterGuiFrame::onIdle)
 wxEND_EVENT_TABLE()
+
+
+void CatheterGuiFrame::onIdle(wxIdleEvent & e)
+{
+	this->statusGridPtr->updateStatus(statusGridCmdPtr);
+	this->statusText->addText(statusTextData);
+}
 
 CatheterGuiFrame::CatheterGuiFrame(const wxString& title, SerialThreadObject* thrdPtr) : 
 wxFrame(NULL, wxID_ANY, title)
@@ -61,13 +69,16 @@ wxFrame(NULL, wxID_ANY, title)
     grid = new CatheterGrid(parentPanel);
 
 	// add the status grid:
-	 statusGridPtr = new StatusGrid(parentPanel);
+	statusGridPtr = new StatusGrid(parentPanel);
     
+	statusGridCmdPtr = new statusData;
 
 	// add the status text.
 	statusText = new CatheterStatusText(parentPanel, wxID_ANY);
-	serialObject->setStatusTextPtr(statusText);
-	serialObject->setStatusGrid(statusGridPtr);
+
+	statusTextData = new incomingText;
+	serialObject->setStatusTextPtr(statusTextData);
+	serialObject->setStatusGrid(statusGridCmdPtr);
     // control buttons (break this up into 2 rows)
 
     // row 1:
@@ -128,6 +139,8 @@ CatheterGuiFrame::~CatheterGuiFrame()
 {
 	//do nothing here 
 	//All windows should be auto cleaned.
+	delete statusGridCmdPtr;
+	delete statusTextData;
 }
 
 
@@ -181,10 +194,14 @@ void CatheterGuiFrame::OnSendCommandsButtonClicked(wxCommandEvent& e) {
 }
 
 
+
+
 void CatheterGuiFrame::OnSendPollButtonClicked(wxCommandEvent& e) {
 	sendPollCommand();
 	setStatusText(wxT("Poll Command Successfully Sent"));
 }
+
+
 
 void CatheterGuiFrame::OnSendResetButtonClicked(wxCommandEvent& e) {
     //setStatusText(wxT("Sending Reset Command...\n"));

--- a/src/catheter_arduino_gui/src/gui/status_frame.cpp
+++ b/src/catheter_arduino_gui/src/gui/status_frame.cpp
@@ -43,26 +43,40 @@ StatusGrid::StatusGrid(wxPanel* parentPanel):
    
 }
 
-void StatusGrid::updateStatus(const std::vector<CatheterChannelCmd> & inputCommands)
+void StatusGrid::updateStatus(statusData* inputData)
 {
-	int cmdCount(inputCommands.size());
-	for (int index(0); index < cmdCount; index++)
+	
+	boost::mutex::scoped_lock lock(inputData->statusMutex);
+	if (inputData->updated)
 	{
-		int channelNum(inputCommands[index].channel);
-		int baseIndex(((channelNum-1) << 2));
-		textCtrl[baseIndex+1]->SetValue(wxString::Format(wxT("%f"), inputCommands[index].currentMilliAmp));
-		textCtrl[baseIndex+2]->SetValue(wxString::Format(wxT("%f"), inputCommands[index].currentMilliAmp_ADC));
-		if (inputCommands[index].enable)
+		int cmdCount(inputData->inputCommands.size());
+		for (int index(0); index < cmdCount; index++)
 		{
-			textCtrl[baseIndex+3]->SetValue(wxT("true"));
+			int channelNum(inputData->inputCommands[index].channel);
+			int baseIndex(((channelNum - 1) << 2));
+			textCtrl[baseIndex + 1]->SetValue(wxString::Format(wxT("%f"), inputData->inputCommands[index].currentMilliAmp));
+			textCtrl[baseIndex + 2]->SetValue(wxString::Format(wxT("%f"), inputData->inputCommands[index].currentMilliAmp_ADC));
+			if (inputData->inputCommands[index].enable)
+			{
+				textCtrl[baseIndex + 3]->SetValue(wxT("true"));
+			}
+			else
+			{
+				textCtrl[baseIndex + 3]->SetValue(wxT("false"));
+			}
 		}
-		else
-		{
-			textCtrl[baseIndex+3]->SetValue(wxT("false"));
-		}
+		inputData->updated = false;
 	}
-
 	return;
+}
+
+
+void statusData::updateCmdList(std::vector<CatheterChannelCmd> & inputCommands_)
+{
+	boost::mutex::scoped_lock lock(this->statusMutex);
+	this->inputCommands = inputCommands_;
+	this->updated = true;
+
 }
 
  /*  wxPanel *panel = new wxPanel(this, -1);

--- a/src/catheter_arduino_gui/src/gui/status_text.cpp
+++ b/src/catheter_arduino_gui/src/gui/status_text.cpp
@@ -10,6 +10,16 @@
    #endif
 #endif  // _DEBUG
 
+
+void incomingText::appendText(const std::string  &newText)
+{
+	boost::mutex::scoped_lock lock(textMutex);
+	this->update = true;
+	stringData += "\n";
+	stringData += newText;
+}
+
+
 // explicit constructor
 CatheterStatusText::CatheterStatusText(wxWindow* parent, wxWindowID id) : wxScrolledWindow(parent, id, wxDefaultPosition, wxSize(50,150)) {
 		
@@ -27,12 +37,18 @@ CatheterStatusText::CatheterStatusText(wxWindow* parent, wxWindowID id) : wxScro
 	}
 
     // public method to send text into the status box
-    bool CatheterStatusText::addText(const std::string &incomingInfo)
-    {
-        boost::mutex::scoped_lock lock(textMutex);
-        SetCatheterStatusText(wxString(incomingInfo));
+bool CatheterStatusText::addText(incomingText *incomingInfo)
+{
+        boost::mutex::scoped_lock lock(incomingInfo->textMutex);
+		if (incomingInfo->update)
+		{
+			SetCatheterStatusText(wxString(incomingInfo->stringData));
+			incomingInfo->stringData.clear();
+		}
+		incomingInfo->update = false;
         return true;
-    }
+}
+
 	bool CatheterStatusText::addWxText(const wxString& msg)
     {
         boost::mutex::scoped_lock lock(textMutex);

--- a/src/catheter_arduino_gui/src/ser/serial_thread.cpp
+++ b/src/catheter_arduino_gui/src/ser/serial_thread.cpp
@@ -41,9 +41,9 @@ void SerialThreadObject::serialLoop()
 			//}
 			if(newCom == valid)
 			{
-				if(gridStatus != NULL)
+				if(statusGridData != NULL)
 				{
-					gridStatus->updateStatus(commandFromArd.commandList);
+					statusGridData->updateCmdList(commandFromArd.commandList);
 				}
 			}
 
@@ -74,9 +74,9 @@ void SerialThreadObject::serialLoop()
 	}
 }
 
-void SerialThreadObject::setStatusGrid(StatusGrid* newPtr)
+void SerialThreadObject::setStatusGrid(statusData* newPtr)
 {
-	gridStatus = newPtr;
+	statusGridData = newPtr;
 }
 
 void SerialThreadObject::serialCommand(const ThreadCmd& incomingCommand)
@@ -101,18 +101,19 @@ void SerialThreadObject::serialCommand(const ThreadCmd& incomingCommand)
 			break;
 			case resetSerial:
 			{
-				if(textStatus != NULL)
+				if(textStatusData != NULL)
 				{
-					textStatus->addWxText(wxT("Attempting to reset Arduino Serial Connection"));
+					textStatusData->appendText(std::string("Attempting to reset Arduino Serial Connection"));
 				}
 				//reset the serial bus.
 				std::vector<std::string> ports;
 				ss->getAvailablePorts(ports);
 
-				if (!ports.size()) {
-					if(textStatus != NULL)
+				if (!ports.size())
+				{
+					if(textStatusData != NULL)
 					{
-						textStatus->addWxText(wxT("No Serial Ports found."));
+						textStatusData->appendText(std::string("No Serial Ports found."));
 					}
 				} 
 				else
@@ -120,9 +121,9 @@ void SerialThreadObject::serialCommand(const ThreadCmd& incomingCommand)
 					if (ports.size() == 1)
 					{
 						ss->setPort(ports[0]);
-						if(textStatus != NULL)
+						if(textStatusData != NULL)
 						{
-							textStatus->addText(std::string("Connecting to Port: ")+ports[0]);
+							textStatusData->appendText(std::string("Connecting to Port: ")+ports[0]);
 						}
 					}
 					else
@@ -134,15 +135,15 @@ void SerialThreadObject::serialCommand(const ThreadCmd& incomingCommand)
 						int which_port(wxGetNumberFromUser(wxEmptyString, wxT("Select Serial Port Number"), wxEmptyString, 0, 1, ports.size()) - 1);
 						wxMessageBox(wxString::Format("Selected Serial Port: %s", wxString(ports[which_port])));
 						ss->setPort(ports[which_port]);
-						if(textStatus != NULL)
+						if(textStatusData != NULL)
 						{
-							textStatus->addText(std::string("Connecting to Port: ")+ports[which_port]);
+							textStatusData->appendText(std::string("Connecting to Port: ")+ports[which_port]);
 						}
 					}
 					connected = ss->start();
-					if(textStatus != NULL)
+					if(textStatusData != NULL)
 					{
-						textStatus->addText(std::string("Connected!!"));
+						textStatusData->appendText(std::string("Connected!!"));
 					}
 				}
 
@@ -159,9 +160,9 @@ void SerialThreadObject::serialCommand(const ThreadCmd& incomingCommand)
 				commandsToArd.push_back(pollCmd());
 			break;
 			default:
-				if(textStatus != NULL)
+				if(textStatusData != NULL)
 				{
-					textStatus->addText(std::string("Command not recognized"));
+					textStatusData->appendText(std::string("Command not recognized"));
 				}
 			}
 			looplock.unlock();
@@ -172,7 +173,7 @@ void SerialThreadObject::serialCommand(const ThreadCmd& incomingCommand)
 
 // explicit constructor
 SerialThreadObject::SerialThreadObject(): connected(false), ss(new CatheterSerialSender), thrd(),
-	textStatus(NULL), gridStatus(NULL)
+	textStatusData(NULL), statusGridData(NULL)
 {
 	// initialize all of the variables.
 	std::vector< CatheterChannelCmd > commandsToArd;
@@ -184,9 +185,9 @@ SerialThreadObject::SerialThreadObject(): connected(false), ss(new CatheterSeria
 
 }
 
-void SerialThreadObject::setStatusTextPtr(CatheterStatusText* textPtr)
+void SerialThreadObject::setStatusTextPtr(incomingText* textPtr)
 {
-	this->textStatus = textPtr;
+	this->textStatusData = textPtr;
 }
 
 void SerialThreadObject::stopThreads()


### PR DESCRIPTION
… thread race conditions. also seperated the status grid.

This is part of a larger effort to improve the operational efficiency of the gui. @kdk49 Please take a look when you get a chance